### PR TITLE
removed the ^ in the second regex.

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -15,7 +15,7 @@ MSG=$(grep -v '^#' $FILE)
 
 if [[ -z "$(echo \"$MSG\" | grep '[A-Z]\+-\d\+')" ]]; then
     BRANCH=$(git symbolic-ref --short HEAD)
-    JIRA_FROM_BRANCH=$(echo "$BRANCH" | grep -o '^[A-Z]\+-\d\+')
+    JIRA_FROM_BRANCH=$(echo "$BRANCH" | grep -o '[A-Z]\+-\d\+')
     if [[ -n "$JIRA_FROM_BRANCH" ]]; then
         echo "$JIRA_URL/$JIRA_FROM_BRANCH" >> $FILE
         echo "Appended '$JIRA_FROM_BRANCH' to commit message (detected from branch name)"


### PR DESCRIPTION
now the text ML_BACKEND-1111 can be found everywhere in the commit title.

So if you have for example feature/ML_BACKEND-1234_test, it will work.